### PR TITLE
[modify] #2 use http on development env

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :test
   host = 'localhost:3000'
-  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
ユーザー登録後に発行されるアクティベーションURLにアクセスできない問題を修正。ローカル開発環境ではSSL化せずにhttpでアクセスする。